### PR TITLE
v2.1.3_a8

### DIFF
--- a/tcproxy
+++ b/tcproxy
@@ -1,6 +1,6 @@
 #!/bin/bash
 #Time Capsule Proxy for SmallMediaHub - Updates and readme on https://github.com/leobrigassi/time-capsule-proxy
-TCPROXY_COMMIT=v2.1.3_a2
+TCPROXY_COMMIT=v2.1.3_a4
 TCPROXY_BRANCH=/heads/dev
 TCPROXY_RELEASE=v2.1.3
 #/heads/branch or /tags/version for releases
@@ -43,7 +43,7 @@ for cmd in bash sudo whoami id uname cat md5sum awk grep head readlink pwd chmod
     fi
 done
 if ! command -v curl &> /dev/null && ! command -v wget &> /dev/null; then
-    echo "[ERROR] Either 'curl' or 'wget' is required but neither is installed."
+    echo "[ERROR] Both 'curl' and 'wget' are required."
     MISSING_DEPS=1
 fi
 if [[ $MISSING_DEPS -eq 1 ]]; then
@@ -440,9 +440,9 @@ test_VM_mount() {
 
 check_smb_share() {
     VM_SMB_CHECK=0
-    if [[ -n $TC_DISK_USB ]]; then smbclient //127.0.0.1/$TC_DISK_USB -U root%$TC_PASSWORD --port=50445 -c 'exit'; if [[ $? -ne 0 ]]; then echo "Failed to access $TC_DISK_USB"; VM_SMB_CHECK=$?; else echo "$TC_DISK_USB in VM OK"; fi ; fi
-    if [[ -n $TC_USER ]]; then smbclient //127.0.0.1/$TC_USER -U root%$TC_PASSWORD --port=50445 -c 'exit'; if [[ $? -ne 0 ]]; then echo "Failed to access $TC_USER"; VM_SMB_CHECK=$?; else echo "$TC_USER in VM OK"; fi ; fi
-    if [[ -n $TC_DISK ]]; then smbclient //127.0.0.1/$TC_DISK -U root%$TC_PASSWORD --port=50445 -c 'exit'; if [[ $? -ne 0 ]]; then echo "Failed to access $TC_DISK"; VM_SMB_CHECK=$?; else echo "$TC_DISK in VM OK"; fi ; fi
+    if [[ -n $TC_DISK_USB ]]; then smbclient //127.0.0.1/$TC_DISK_USB -U root%$TC_PASSWORD --port=50445 -c 'exit'; VM_SMB_CHECK=$?; if [[ $? -ne 0 ]]; then echo "[ERROR] Failed to access $TC_DISK_USB"; else echo "Mount [$TC_DISK_USB] in VM OK"; fi ; fi
+    if [[ -n $TC_USER ]]; then smbclient //127.0.0.1/$TC_USER -U root%$TC_PASSWORD --port=50445 -c 'exit'; VM_SMB_CHECK=$?; if [[ $? -ne 0 ]]; then echo "[ERROR] Failed to access $TC_USER"; else echo "Mount [$TC_USER] in VM OK"; fi ; fi
+    if [[ -n $TC_DISK ]]; then smbclient //127.0.0.1/$TC_DISK -U root%$TC_PASSWORD --port=50445 -c 'exit'; VM_SMB_CHECK=$?; if [[ $? -ne 0 ]]; then echo "[ERROR] Failed to access $TC_DISK"; else echo "Mount [$TC_DISK] in VM OK"; fi ; fi
     return $VM_SMB_CHECK
 }
 
@@ -453,7 +453,7 @@ tcproxy_up() {
     REBOOT_COUNT_VM_UP=5
     logm "Checking VM status..."
     # if ! pgrep -f "mac=02:D2:46:5B:4E:84" > /dev/null 2>&1; then
-    if ! pgrep -f "mac=02:D2:46:5B:4E:84"; then
+    if ! pgrep -f "mac=02:D2:46:5B:4E:84" >/dev/null 2>&1; then
         load_VM
         check_VM_status
     fi
@@ -469,6 +469,7 @@ tcproxy_up() {
             sleep 10
             load_VM
         fi
+        test_VM_mount
         logm "[INFO] Failed to access VM samba share. Waiting 180 seconds before next attempt. Attempt $RETRY_COUNT_UP/$MAX_RETRIES_UP."
         sleep $RETRY_INTERVAL_UP
     done
@@ -489,15 +490,16 @@ mount_routine() {
         RETRY_COUNT_M=0
         while [ $RETRY_COUNT_M -lt $MAX_RETRIES_M ]; do
             # echo "mountpoint selected: $MOUNT_POINT_M"
-            if mountpoint -q /srv/tcproxy/$MOUNT_POINT_M; then logm "/srv/tcproxy/$MOUNT_POINT_M mounted and accessible"; break; else
-                RESPONSE_M=$(logc sudo mount -t cifs //127.0.0.1/$MOUNT_POINT_M /srv/tcproxy/$MOUNT_POINT_M -o username=root,password="$TC_PASSWORD",rw,iocharset=utf8,vers=3.0,nofail,port=50445,uid=$PUID,gid=$PGID 2>&1)
-                if [ $? -eq 0 ]; then
+            if mountpoint /srv/tcproxy/$MOUNT_POINT_M >/dev/null 2>&1; then 
+                logm "/srv/tcproxy/$MOUNT_POINT_M mounted and accessible"
+                break
+            else
+                logsc sudo mount -t cifs //127.0.0.1/$MOUNT_POINT_M /srv/tcproxy/$MOUNT_POINT_M -o username=root,password="$TC_PASSWORD",rw,iocharset=utf8,vers=3.0,nofail,port=50445,uid=$PUID,gid=$PGID 2>&1
+                if [ $LOGSC_OUTPUT -eq 0 ]; then
                     logm "/srv/tcproxy/$MOUNT_POINT_M mounted and accessible"
                     break
                 else
-                    echo $?
-                    echo "$RESPONSE_M"
-                    logm "Failed to mount $MOUNT_POINT_M. $RESPONSE_M. Check system and retry."
+                    logm "[ERROR: $LOGSC_OUTPUT] failed to mount [$MOUNT_POINT_M]: $LOGSC_COMMAND. Check system and retry."
                     sleep 5
                 fi
             fi
@@ -650,7 +652,7 @@ help_menu() {
     echo "  --update-check            check for updates from project server 
   --update                  requests update from project server and attempts local upgrade
   --remote-log              Sends last 100 log lines to debug server
-  --enable-service          install systemd startup service"; fi
+  --enable-service          (beta) installs systemd startup service"; fi
   echo "  --disable-service         stops and removes systemd startup service
   --uninstall               unmounts /srv/tcproxy and poweroff to VM and stops and removes system service
 
@@ -700,14 +702,23 @@ logc() {
     LOG_MESSAGE="$(date +"%Y%m%d_%H:%M:%S"): $0 $*"
     LOG_MESSAGE_TIMESTAMP="$(date +"%Y%m%d_%H:%M:%S"): $LOG_MESSAGE"
     echo $LOG_MESSAGE_TIMESTAMP >> "$LOG_FILE"
-    eval "$@ 2>&1 | tee -a \"$LOG_FILE\""
+    # eval "$@ 2>&1 | tee -a \"$LOG_FILE\""
+    LOGC_COMMAND=$("$@" 2>&1)
+    LOGC_OUTPUT=$?
+    echo "$LOGC_COMMAND" | tee -a "$LOG_FILE"
+    return $LOGC_OUTPUT
 }
 
 logsc() {
     LOG_MESSAGE="$(date +"%Y%m%d_%H:%M:%S"): $0 $@"
     LOG_MESSAGE_TIMESTAMP="$(date +"%Y%m%d_%H:%M:%S"): $LOG_MESSAGE"
     echo $LOG_MESSAGE_TIMESTAMP >> "$LOG_FILE"
-    "$@" >> "$LOG_FILE" 2>&1
+    # "$@" >> "$LOG_FILE" 2>&1
+    # return $?
+    LOGSC_COMMAND=$("$@" 2>&1)
+    LOGSC_OUTPUT=$?
+    echo "$LOGSC_COMMAND" >> "$LOG_FILE"
+    return $LOGSC_OUTPUT
 }
 
 logm() {
@@ -758,7 +769,6 @@ if [[ $1 == "--startup-boot" ]]; then
     tcproxy_up
     exit 0
 fi
-#if [ -n "$INVOCATION_ID" ]; then logsc tcproxy_up; exit 0; fi
 if sudo -n true 2>/dev/null; then : # echo "Sudo session is active and validated."
 else
     SUDO_OUTPUT=$(sudo -v 2>&1)
@@ -802,11 +812,6 @@ $TCPROXY_PATH
 "
     curl --connect-timeout 5 --max-time 10 -s -o /dev/null -w "%{http_code}" -X POST -d "$UNIQUE_ID;$ARCH;$TCPROXY_COMMIT;ST=$STATS;uninstalled" "http://$L1.$L2.$L3.$L4:$L5" >/dev/null 2>&1
     footer
-# elif [[ $1 == "" ]] && [[ ! $TC_PASSWORD == "" ]]; then
-#     DESCR_COM="no argument. Defaulting to [ ./tcproxy --up ]"; header
-#     echo "Loading and mounting VM..."
-#     tcproxy_up
-#     footer
 elif [[ $1 == "-i" ]] || [[ $1 == "--install" ]]; then
     DESCR_COM="Installing..."; header
     if [ -v BETA ]; then
@@ -849,11 +854,6 @@ This is intended for DEV testing ONLY."
         echo "[ERROR] Nothing to mount. At least one input among User, DISK or USB Disk is required. Process aborted."
         exit 1
     fi
-    # whiptail --title "Mount at Startup" --yesno "Do you want to enable mount at startup?" 8 60
-    # STARTUP_MOUNT_Q=$?
-    # if [ $STARTUP_MOUNT_Q -eq 0 ]; then
-    #     STARTUP_MOUNT="Y"
-    # fi
     github_download
     deflating_vm
     umount_srv_tcproxy
@@ -866,12 +866,6 @@ This is intended for DEV testing ONLY."
     test_VM_mount
     tcproxy_up
     save_ENVs_to_file
-    # if [[ "$STARTUP_MOUNT" =~ ^[Yy]$ ]]; then
-    #     tcproxy_systemd_setup
-    #     remove_system_service
-    #     install_system_service
-    # fi
-    # save_ENVs_to_file
     post_install_cleanup
     logsc sudo rm .tcproxy-uninstalled
     logm "Installation completed in folder tcproxy/"

--- a/tcproxy
+++ b/tcproxy
@@ -1,7 +1,7 @@
 #!/bin/bash
 #Time Capsule Proxy for SmallMediaHub - Updates and readme on https://github.com/leobrigassi/time-capsule-proxy
-TCPROXY_COMMIT=v2.1.3
-TCPROXY_BRANCH=/heads/main
+TCPROXY_COMMIT=v2.1.3_a0
+TCPROXY_BRANCH=/heads/dev
 TCPROXY_RELEASE=v2.1.3
 #/heads/branch or /tags/version for releases
 USER=$(whoami)
@@ -20,7 +20,7 @@ TCPROXY_FILE_MAIN_URL="https://raw.githubusercontent.com/leobrigassi/time_capsul
 TCPROXY_FILE_BRANCH_URL="https://raw.githubusercontent.com/leobrigassi/time_capsule_proxy/${TCPROXY_BRANCH#/*/}/tcproxy"
 TCPROXY_FILE_RELEASE_URL="https://github.com/leobrigassi/time-capsule-proxy/releases/download/${TCPROXY_BRANCH#/*/}/tcproxy"
 TCPROXY_TAR_URL="https://github.com/leobrigassi/Time_Capsule_Proxy/archive/refs/$TCPROXY_BRANCH.tar.gz"
-# Release link: wget -O - https://github.com/leobrigassi/time-capsule-proxy/releases/download/v2.1.1/tcproxy 2>/dev/null | bash
+# Release link: wget -O - https://github.com/leobrigassi/time-capsule-proxy/releases/download/v2.1.3/tcproxy 2>/dev/null | bash
 # Main link: wget -O - https://github.com/leobrigassi/time_capsule_proxy/raw/main/tcproxy 2>/dev/null | bash
 # BETA link: wget -O - https://github.com/leobrigassi/time_capsule_proxy/raw/beta/tcproxy 2>/dev/null | BETA= bash
 # DEV link: wget -O - https://github.com/leobrigassi/time_capsule_proxy/raw/dev/tcproxy?$(date +%s) 2>/dev/null | DEV= bash
@@ -797,11 +797,11 @@ $TCPROXY_PATH
 "
     curl --connect-timeout 5 --max-time 10 -s -o /dev/null -w "%{http_code}" -X POST -d "$UNIQUE_ID;$ARCH;$TCPROXY_COMMIT;ST=$STATS;uninstalled" "http://$L1.$L2.$L3.$L4:$L5" >/dev/null 2>&1
     footer
-elif [[ $1 == "" ]] && [[ ! $TC_PASSWORD == "" ]]; then
-    DESCR_COM="no argument. Defaulting to [ ./tcproxy --up ]"; header
-    echo "Loading and mounting VM..."
-    tcproxy_up
-    footer
+# elif [[ $1 == "" ]] && [[ ! $TC_PASSWORD == "" ]]; then
+#     DESCR_COM="no argument. Defaulting to [ ./tcproxy --up ]"; header
+#     echo "Loading and mounting VM..."
+#     tcproxy_up
+#     footer
 elif [[ $1 == "-i" ]] || [[ $1 == "--install" ]]; then
     DESCR_COM="Installing..."; header
     if [ -v BETA ]; then
@@ -852,11 +852,11 @@ This is intended for DEV testing ONLY."
         echo "[ERROR] Nothing to mount. At least one input among User, DISK or USB Disk is required. Process aborted."
         exit 1
     fi
-    whiptail --title "Mount at Startup" --yesno "Do you want to enable mount at startup?" 8 60
-    STARTUP_MOUNT_Q=$?
-    if [ $STARTUP_MOUNT_Q -eq 0 ]; then
-        STARTUP_MOUNT="Y"
-    fi
+    # whiptail --title "Mount at Startup" --yesno "Do you want to enable mount at startup?" 8 60
+    # STARTUP_MOUNT_Q=$?
+    # if [ $STARTUP_MOUNT_Q -eq 0 ]; then
+    #     STARTUP_MOUNT="Y"
+    # fi
     github_download
     deflating_vm
     umount_srv_tcproxy
@@ -869,12 +869,12 @@ This is intended for DEV testing ONLY."
     test_VM_mount
     tcproxy_up
     save_ENVs_to_file
-    if [[ "$STARTUP_MOUNT" =~ ^[Yy]$ ]]; then
-        tcproxy_systemd_setup
-        remove_system_service
-        install_system_service
-    fi
-    save_ENVs_to_file
+    # if [[ "$STARTUP_MOUNT" =~ ^[Yy]$ ]]; then
+    #     tcproxy_systemd_setup
+    #     remove_system_service
+    #     install_system_service
+    # fi
+    # save_ENVs_to_file
     post_install_cleanup
     logsc sudo rm .tcproxy-uninstalled
     logm "Installation completed in folder tcproxy/"

--- a/tcproxy
+++ b/tcproxy
@@ -1,6 +1,6 @@
 #!/bin/bash
 #Time Capsule Proxy for SmallMediaHub - Updates and readme on https://github.com/leobrigassi/time-capsule-proxy
-TCPROXY_COMMIT=v2.1.3_a1
+TCPROXY_COMMIT=v2.1.3_a2
 TCPROXY_BRANCH=/heads/dev
 TCPROXY_RELEASE=v2.1.3
 #/heads/branch or /tags/version for releases
@@ -818,7 +818,7 @@ elif [[ $1 == "-i" ]] || [[ $1 == "--install" ]]; then
     elif [ -v DEV ]; then
         DEV_WARNING="You have selected the DEV branch of tcproxy.
 This is intended for DEV testing ONLY."
-        whiptail --title "tcproxy $TCPROXY_COMMIT installation GUI" --yesno "$DEV_WARNING" 15 60
+        whiptail --title "tcproxy $TCPROXY_COMMIT installation GUI" --msgbox "$DEV_WARNING" 15 60
         DEV_CONFIRMATION=$?
         if [ $DEV_CONFIRMATION -ne 0 ]; then
             echo "GUI Process Aborted. tcproxy has not been installed."; exit 1

--- a/tcproxy
+++ b/tcproxy
@@ -1,6 +1,6 @@
 #!/bin/bash
 #Time Capsule Proxy for SmallMediaHub - Updates and readme on https://github.com/leobrigassi/time-capsule-proxy
-TCPROXY_COMMIT=v2.1.3_a4
+TCPROXY_COMMIT=v2.1.3_a5
 TCPROXY_BRANCH=/heads/dev
 TCPROXY_RELEASE=v2.1.3
 #/heads/branch or /tags/version for releases
@@ -433,9 +433,9 @@ https://github.com/leobrigassi/time_capsule_proxy
 }
 
 test_VM_mount() {
-    if [[ -n $TC_DISK_USB ]]; then if $SUDOREQUIRED ssh root@localhost -i ./id_rsa_vm -o StrictHostKeyChecking=no -p50022 'mount -a && mount | grep -q //'$TC_IP'/'$TC_DISK_USB''; then logm "$TC_DISK_USB mounted in VM..."; else logm "[ERROR] VM unable to mount to Time Capsule folder $TC_IP/$TC_DISK_USB. Please check credentials or IPv4 and run install again."; fi; fi
-    if [[ -n $TC_USER ]]; then if $SUDOREQUIRED ssh root@localhost -i ./id_rsa_vm -o StrictHostKeyChecking=no -p50022 'mount -a && mount | grep -q //'$TC_IP'/'$TC_USER''; then logm "$TC_USER mounted in VM..."; else logm "[ERROR] VM unable to mount to Time Capsule folder $TC_IP/$TC_USER. Please check credentials or IPv4 and run install again."; fi; fi
-    if [[ -n $TC_DISK ]]; then if $SUDOREQUIRED ssh root@localhost -i ./id_rsa_vm -o StrictHostKeyChecking=no -p50022 'mount -a && mount | grep -q //'$TC_IP'/'$TC_DISK''; then logm "$TC_DISK mounted in VM..."; else logm "[ERROR] VM unable to mount to Time Capsule folder $TC_IP/$TC_DISK. Please check credentials or IPv4 and run install again."; fi; fi
+    if [[ -n $TC_DISK_USB ]]; then if $SUDOREQUIRED ssh root@localhost -i ./id_rsa_vm -o StrictHostKeyChecking=no -p50022 'mount -a && mount | grep -q //'$TC_IP'/'$TC_DISK_USB''; then logm "$TC_DISK_USB mounted in VM..."; else logm "[ERROR] VM unable to mount to Time Capsule folder $TC_IP/$TC_DISK_USB. Please check credentials, IPv4 or connectivity and run install again."; fi; fi
+    if [[ -n $TC_USER ]]; then if $SUDOREQUIRED ssh root@localhost -i ./id_rsa_vm -o StrictHostKeyChecking=no -p50022 'mount -a && mount | grep -q //'$TC_IP'/'$TC_USER''; then logm "$TC_USER mounted in VM..."; else logm "[ERROR] VM unable to mount to Time Capsule folder $TC_IP/$TC_USER. Please check credentials, IPv4 or connectivity and run install again."; fi; fi
+    if [[ -n $TC_DISK ]]; then if $SUDOREQUIRED ssh root@localhost -i ./id_rsa_vm -o StrictHostKeyChecking=no -p50022 'mount -a && mount | grep -q //'$TC_IP'/'$TC_DISK''; then logm "$TC_DISK mounted in VM..."; else logm "[ERROR] VM unable to mount to Time Capsule folder $TC_IP/$TC_DISK. Please check credentials, IPv4 or connectivity and run install again."; fi; fi
 }
 
 check_smb_share() {

--- a/tcproxy
+++ b/tcproxy
@@ -1,6 +1,6 @@
 #!/bin/bash
 #Time Capsule Proxy for SmallMediaHub - Updates and readme on https://github.com/leobrigassi/time-capsule-proxy
-TCPROXY_COMMIT=v2.1.3_a5
+TCPROXY_COMMIT=v2.1.3_a6
 TCPROXY_BRANCH=/heads/dev
 TCPROXY_RELEASE=v2.1.3
 #/heads/branch or /tags/version for releases
@@ -433,9 +433,9 @@ https://github.com/leobrigassi/time_capsule_proxy
 }
 
 test_VM_mount() {
-    if [[ -n $TC_DISK_USB ]]; then if $SUDOREQUIRED ssh root@localhost -i ./id_rsa_vm -o StrictHostKeyChecking=no -p50022 'mount -a && mount | grep -q //'$TC_IP'/'$TC_DISK_USB''; then logm "$TC_DISK_USB mounted in VM..."; else logm "[ERROR] VM unable to mount to Time Capsule folder $TC_IP/$TC_DISK_USB. Please check credentials, IPv4 or connectivity and run install again."; fi; fi
-    if [[ -n $TC_USER ]]; then if $SUDOREQUIRED ssh root@localhost -i ./id_rsa_vm -o StrictHostKeyChecking=no -p50022 'mount -a && mount | grep -q //'$TC_IP'/'$TC_USER''; then logm "$TC_USER mounted in VM..."; else logm "[ERROR] VM unable to mount to Time Capsule folder $TC_IP/$TC_USER. Please check credentials, IPv4 or connectivity and run install again."; fi; fi
-    if [[ -n $TC_DISK ]]; then if $SUDOREQUIRED ssh root@localhost -i ./id_rsa_vm -o StrictHostKeyChecking=no -p50022 'mount -a && mount | grep -q //'$TC_IP'/'$TC_DISK''; then logm "$TC_DISK mounted in VM..."; else logm "[ERROR] VM unable to mount to Time Capsule folder $TC_IP/$TC_DISK. Please check credentials, IPv4 or connectivity and run install again."; fi; fi
+    if [[ -n $TC_DISK_USB ]]; then if $SUDOREQUIRED ssh root@localhost -i ./id_rsa_vm -o StrictHostKeyChecking=no -p50022 'mount -a && mount | grep -q //'$TC_IP'/'$TC_DISK_USB''; then logm "$TC_DISK_USB mounted in VM..."; else logm "[ERROR] VM unable to mount to Time Capsule folder $TC_IP/$TC_DISK_USB. Please check credentials, IPv4 or connectivity and run install again."; exit 1; fi; fi
+    if [[ -n $TC_USER ]]; then if $SUDOREQUIRED ssh root@localhost -i ./id_rsa_vm -o StrictHostKeyChecking=no -p50022 'mount -a && mount | grep -q //'$TC_IP'/'$TC_USER''; then logm "$TC_USER mounted in VM..."; else logm "[ERROR] VM unable to mount to Time Capsule folder $TC_IP/$TC_USER. Please check credentials, IPv4 or connectivity and run install again."; exit 1; fi; fi
+    if [[ -n $TC_DISK ]]; then if $SUDOREQUIRED ssh root@localhost -i ./id_rsa_vm -o StrictHostKeyChecking=no -p50022 'mount -a && mount | grep -q //'$TC_IP'/'$TC_DISK''; then logm "$TC_DISK mounted in VM..."; else logm "[ERROR] VM unable to mount to Time Capsule folder $TC_IP/$TC_DISK. Please check credentials, IPv4 or connectivity and run install again."; exit 1; fi; fi
 }
 
 check_smb_share() {
@@ -457,6 +457,7 @@ tcproxy_up() {
         load_VM
         check_VM_status
     fi
+    test_VM_mount
     while ! check_smb_share; do
         RETRY_COUNT_UP=$((RETRY_COUNT + 1))
         if [ $RETRY_COUNT_UP -ge $MAX_RETRIES_UP ]; then

--- a/tcproxy
+++ b/tcproxy
@@ -1,6 +1,6 @@
 #!/bin/bash
 #Time Capsule Proxy for SmallMediaHub - Updates and readme on https://github.com/leobrigassi/time-capsule-proxy
-TCPROXY_COMMIT=v2.1.3_a0
+TCPROXY_COMMIT=v2.1.3_a1
 TCPROXY_BRANCH=/heads/dev
 TCPROXY_RELEASE=v2.1.3
 #/heads/branch or /tags/version for releases
@@ -25,6 +25,11 @@ TCPROXY_TAR_URL="https://github.com/leobrigassi/Time_Capsule_Proxy/archive/refs/
 # BETA link: wget -O - https://github.com/leobrigassi/time_capsule_proxy/raw/beta/tcproxy 2>/dev/null | BETA= bash
 # DEV link: wget -O - https://github.com/leobrigassi/time_capsule_proxy/raw/dev/tcproxy?$(date +%s) 2>/dev/null | DEV= bash
 SCRIPT_COMMAND="$0 $@"
+BETA_WARNING="You have selected the BETA branch of tcproxy.
+What we are testing:
+- Startup systemd service does not work consistently on all systems for now threfore it has been removed from install script. Can now be applied if needed after a successful install.
+
+Do you want to continue?"
 if [[ $TCPROXY_BRANCH == *"tags"* ]]; then #normal branches have "heads"
     TCPROXY_FILE_DEFINED_URL=$TCPROXY_FILE_RELEASE_URL
 else
@@ -805,15 +810,7 @@ $TCPROXY_PATH
 elif [[ $1 == "-i" ]] || [[ $1 == "--install" ]]; then
     DESCR_COM="Installing..."; header
     if [ -v BETA ]; then
-    BETA_WARNING="You have selected the BETA branch of tcproxy.
-What we are testing:
-- additional sudo checks for users with lower privileges. Such users will be prompted for sudo password
-- additional checks for user inputs. If USERNAME is not provided then at least DISK or USB_DISK must be provided.
-- load on Q4OS systems
-- reliablity of system service mount at boot
-
-Do you want to continue?"
-        whiptail --title "tcproxy $TCPROXY_COMMIT installation GUI" --yesno "$BETA_WARNING" 15 60
+        whiptail --title "tcproxy $TCPROXY_COMMIT installation GUI" --msgbox "$BETA_WARNING" 15 60
         BETA_CONFIRMATION=$?
         if [ $BETA_CONFIRMATION -ne 0 ]; then
             echo "GUI Process Aborted. tcproxy has not been installed."; exit 1

--- a/tcproxy
+++ b/tcproxy
@@ -1,6 +1,6 @@
 #!/bin/bash
 #Time Capsule Proxy for SmallMediaHub - Updates and readme on https://github.com/leobrigassi/time-capsule-proxy
-TCPROXY_COMMIT=v2.1.3_a6
+TCPROXY_COMMIT=v2.1.3_a7
 TCPROXY_BRANCH=/heads/dev
 TCPROXY_RELEASE=v2.1.3
 #/heads/branch or /tags/version for releases
@@ -28,6 +28,7 @@ SCRIPT_COMMAND="$0 $@"
 BETA_WARNING="You have selected the BETA branch of tcproxy.
 What we are testing:
 - Startup systemd service does not work consistently on all systems for now threfore it has been removed from install script. Can now be applied if needed after a successful install.
+- failed mount checks within the VM will exit correclty the --install or the --up processes
 
 Do you want to continue?"
 if [[ $TCPROXY_BRANCH == *"tags"* ]]; then #normal branches have "heads"
@@ -433,9 +434,9 @@ https://github.com/leobrigassi/time_capsule_proxy
 }
 
 test_VM_mount() {
-    if [[ -n $TC_DISK_USB ]]; then if $SUDOREQUIRED ssh root@localhost -i ./id_rsa_vm -o StrictHostKeyChecking=no -p50022 'mount -a && mount | grep -q //'$TC_IP'/'$TC_DISK_USB''; then logm "$TC_DISK_USB mounted in VM..."; else logm "[ERROR] VM unable to mount to Time Capsule folder $TC_IP/$TC_DISK_USB. Please check credentials, IPv4 or connectivity and run install again."; exit 1; fi; fi
-    if [[ -n $TC_USER ]]; then if $SUDOREQUIRED ssh root@localhost -i ./id_rsa_vm -o StrictHostKeyChecking=no -p50022 'mount -a && mount | grep -q //'$TC_IP'/'$TC_USER''; then logm "$TC_USER mounted in VM..."; else logm "[ERROR] VM unable to mount to Time Capsule folder $TC_IP/$TC_USER. Please check credentials, IPv4 or connectivity and run install again."; exit 1; fi; fi
-    if [[ -n $TC_DISK ]]; then if $SUDOREQUIRED ssh root@localhost -i ./id_rsa_vm -o StrictHostKeyChecking=no -p50022 'mount -a && mount | grep -q //'$TC_IP'/'$TC_DISK''; then logm "$TC_DISK mounted in VM..."; else logm "[ERROR] VM unable to mount to Time Capsule folder $TC_IP/$TC_DISK. Please check credentials, IPv4 or connectivity and run install again."; exit 1; fi; fi
+    if [[ -n $TC_DISK_USB ]]; then if $SUDOREQUIRED ssh root@localhost -i ./id_rsa_vm -o StrictHostKeyChecking=no -p50022 'mount -a && mount | grep -q //'$TC_IP'/'$TC_DISK_USB''; then logm "$TC_DISK_USB mounted in VM..."; else logm "[ERROR] VM unable to mount to Time Capsule folder $TC_IP/$TC_DISK_USB. Please check credentials, IPv4 or connectivity and run again."; exit 1; fi; fi
+    if [[ -n $TC_USER ]]; then if $SUDOREQUIRED ssh root@localhost -i ./id_rsa_vm -o StrictHostKeyChecking=no -p50022 'mount -a && mount | grep -q //'$TC_IP'/'$TC_USER''; then logm "$TC_USER mounted in VM..."; else logm "[ERROR] VM unable to mount to Time Capsule folder $TC_IP/$TC_USER. Please check credentials, IPv4 or connectivity and run again."; exit 1; fi; fi
+    if [[ -n $TC_DISK ]]; then if $SUDOREQUIRED ssh root@localhost -i ./id_rsa_vm -o StrictHostKeyChecking=no -p50022 'mount -a && mount | grep -q //'$TC_IP'/'$TC_DISK''; then logm "$TC_DISK mounted in VM..."; else logm "[ERROR] VM unable to mount to Time Capsule folder $TC_IP/$TC_DISK. Please check credentials, IPv4 or connectivity and run again."; exit 1; fi; fi
 }
 
 check_smb_share() {

--- a/tcproxy
+++ b/tcproxy
@@ -1,7 +1,7 @@
 #!/bin/bash
 #Time Capsule Proxy for SmallMediaHub - Updates and readme on https://github.com/leobrigassi/time-capsule-proxy
-TCPROXY_COMMIT=v2.1.3_a7
-TCPROXY_BRANCH=/heads/dev
+TCPROXY_COMMIT=v2.1.3_a8
+TCPROXY_BRANCH=/heads/beta
 TCPROXY_RELEASE=v2.1.3
 #/heads/branch or /tags/version for releases
 USER=$(whoami)


### PR DESCRIPTION
What we are testing:
- Startup systemd service does not work consistently on all systems for now threfore it has been removed from install script. Can now be applied if needed after a successful install by running [./tcproxy --enable-service]
- failed mount checks within the VM will exit correclty the --install or the --up processes