### PR TITLE
v2.1.5

### DIFF
--- a/tcproxy
+++ b/tcproxy
@@ -1,8 +1,8 @@
 #!/bin/bash
 #Time Capsule Proxy for SmallMediaHub - Updates and readme on https://github.com/leobrigassi/time-capsule-proxy
-TCPROXY_COMMIT=v2.1.4_c7
-TCPROXY_BRANCH=/heads/beta
-TCPROXY_RELEASE=v2.1.4
+TCPROXY_COMMIT=v2.1.5
+TCPROXY_BRANCH=/heads/main
+TCPROXY_RELEASE=v2.1.5
 TCPROXY_VM_VERSION=v2.1.4
 #/heads/branch or /tags/version for releases
 USER=$(whoami)


### PR DESCRIPTION
- selective download of VM relevant to host arch reducing install download by 50%
- if script named [ after_tcproxy_up ] exists in tcproxy folder it will be executed after tcproxy mount is successfull. Useful to restart services such as Plex so that new mounts can be crawled."
